### PR TITLE
Add setRouter and setView support for controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Hence, a typical controller may look like:
         protected $app;
         protected $request;
         protected $response;
+        protected $router;
+        protected $view;
 
         public function index()
         {
@@ -82,11 +84,21 @@ Hence, a typical controller may look like:
         {
             $this->response = $response;
         }
+        
+        public function setRouter($router)
+        {
+            $this->router = $router;
+        }
+        
+        public function setView($view)
+        {
+            $this->view = $view;
+        }
 
         // Init
         public function init()
         {
-            // do things now that app, request and response are set.
+            // do things now that app, request, response, router and view are set.
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ You can also register the controller with Slim's DI container:
 
 ## Controller class methods
 
-*RKA Slim Controller* will call the controller's `setApp()`, `setRequest()`
-and `setResponse()` methods if they exist and populate appropriately. It will
-then call the controller's `init()`` method.
+*RKA Slim Controller* will call the controller's `setApp()`, `setRequest()`,
+`setResponse()`, `setRouter()` and `setView()` methods if they exist and populate appropriately.
+It will then call the controller's `init()` method.
 
 Hence, a typical controller may look like:
 

--- a/RKA/Slim.php
+++ b/RKA/Slim.php
@@ -69,6 +69,12 @@ class Slim extends \Slim\Slim
             if (method_exists($controller, 'setResponse')) {
                 $controller->setResponse($app->response);
             }
+            if (method_exists($controller, 'setRouter')) {
+                $controller->setRouter($app->router);
+            }
+            if (method_exists($controller, 'setView')) {
+                $controller->setView($app->view);
+            }
 
             // Call init in case the controller wants to do something now that
             // it has an app, request and response.


### PR DESCRIPTION
I've added the hability to automatically inject the view and router objects to controllers if they have the proper methods defined, the same way that is done with the request, the response and the app objects.
This way it is easier to decouple controllers from the app object and still be able to access route params or render templates.
